### PR TITLE
uri-js package is updated to the latest major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/dmtucker/gjtk-js",
   "dependencies": {
     "point-in-polygon": "^0.0.0",
-    "uri-js": "^1.4.2"
+    "uri-js": "^2.1.0"
   }
 }


### PR DESCRIPTION
Hi. I've faced to problem, that `gjtk` fails in `io.js` (strict mode). I found out, that `uri-js` dependency version is pretty old, so I've updated it to the latest major version.
See https://github.com/balderdashy/waterline/issues/1080 for more details. 
Thanks